### PR TITLE
docs(license): add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ The script implements a wrapper around the standard `uv` command that:
 
 ## License
 
-See the LICENSE file for details.
+See the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the reference to the LICENSE file to use a markdown link format.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58): Updated the reference to the LICENSE file to use a markdown link format.