### PR TITLE
refactor(shell): passing extra flags if provided

### DIFF
--- a/uv-shell.sh
+++ b/uv-shell.sh
@@ -88,7 +88,8 @@ function uv() {
 
         # Create venv if needed
         if [[ ! -d "$venv_path" ]]; then
-            command uv venv "$venv_path"
+            shift
+            command uv venv "$venv_path" "$@"
         fi
 
         # Get bin directory based on platform


### PR DESCRIPTION
This pull request includes a small change to the `uv-shell.sh` file. The change modifies the `uv` function to pass additional arguments when creating a virtual environment.

* [`uv-shell.sh`](diffhunk://#diff-f0d05f31aa090fb249167edaec562faea267de3e710b03894eca6a131464db0bL91-R92): Modified the `uv` function to pass all additional arguments to the `uv venv` command.