### PR TITLE
ci(workflows): add pr & release workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+triage:
+  - changed-files:
+      - any-glob-to-any-file: "**/*"
+
+enhancement:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*"
+
+workflows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**/*"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.md
+          - "**/*.md"
+          - "docs/**/*.md"
+          - "docs/mkdocs.yml"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,51 @@
+# .github/release.yml
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - wip
+      - draft
+      - development
+    authors:
+      - octocat
+      - ptah-lgtm
+  categories:
+    - title: ⚡️ Breaking Changes
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: 🎁 New Features
+      labels:
+        - Semver-Minor
+        - feat
+        - feature
+    - title: ⚒️ Enhancement & Maintenance
+      labels:
+        - Semver-Minor
+        - refactor
+        - enhancement
+    - title: 🏗️ CI, Workflows & Some minor changes
+      labels:
+        - Semver-Patch
+        - ci
+        - ops
+        - workflow
+        - chore
+        - style
+    - title: 🐛 Bug Fixes
+      labels:
+        - Semver-Patch
+        - fix
+    - title: 🥵 Hotfix
+      labels:
+        - Semver-Patch
+        - hotfix
+    - title: 📚 Docs
+      labels:
+        - documentation
+    - title: Reverts
+      labels:
+        - revert
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,26 @@
+name: "pull request workflow"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: pr labeler
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,37 @@
+name: semantic release
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: "If you are sure to launch a new release, put the value to true."
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+  statuses: write
+
+jobs:
+  semantic-release:
+    if: github.event.inputs.prompt == 'true'
+    uses: benbenbang/uv-shell/.github/workflows/reusable-sr.yml@workflows
+    secrets: inherit
+
+  update-release-title:
+    runs-on: ubuntu-latest
+    needs: semantic-release
+    if: ${{ needs.semantic-release.outputs.new_release != null }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: update github release
+        run: |
+          gh release edit -R ${{ github.repository }} --title "☀️ UV Shell ${{ needs.semantic-release.outputs.new_release_tag }}" "${{ needs.semantic-release.outputs.new_release_tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request introduces several changes to the GitHub workflows and configuration files to enhance automation and streamline processes. The most important changes include adding a labeler configuration, defining a release process, and setting up workflows for pull requests and semantic releases.

### Enhancements to GitHub Workflows and Configuration:

* **Labeler Configuration**:
  * Added a new labeler configuration in `.github/labeler.yml` to automatically categorize pull requests and issues based on file changes.

* **Release Process**:
  * Defined a new release configuration in `.github/release.yml` to categorize changes in the changelog and exclude specific labels and authors.

* **Pull Request Workflow**:
  * Created a new workflow in `.github/workflows/pull-request.yml` to automatically label pull requests when they are opened or updated.

* **Semantic Release Workflow**:
  * Added a semantic release workflow in `.github/workflows/semantic-release.yml` to automate the release process, including updating the release title based on the new release tag.