### PR TITLE
ci(workflow): add release rc json file

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,134 @@
+{
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES"
+          ]
+        },
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "breaking": true,
+            "release": "major"
+          },
+          {
+            "release": "minor",
+            "type": "feat"
+          },
+          {
+            "release": "patch",
+            "type": "perf"
+          },
+          {
+            "release": "patch",
+            "type": "build"
+          },
+          {
+            "release": "patch",
+            "type": "ops"
+          },
+          {
+            "release": "patch",
+            "type": "refactor"
+          },
+          {
+            "release": "patch",
+            "type": "hotfix"
+          },
+          {
+            "release": "patch",
+            "type": "revert"
+          },
+          {
+            "release": "patch",
+            "type": "fix"
+          }
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/github",
+      {
+        "githubUrl": "https://api.github.com"
+      }
+    ]
+  ],
+  "preset": "conventionalcommits",
+  "presetConfig": {
+    "types": [
+      {
+        "section": ":zap: Breaking Changes",
+        "type": "*"
+      },
+      {
+        "hidden": false,
+        "section": ":gift: Features",
+        "type": "feat"
+      },
+      {
+        "hidden": false,
+        "section": ":hammer_and_pick: Enhancement & Maintenance",
+        "type": "refactor"
+      },
+      {
+        "hidden": false,
+        "section": ":hotsprings: CI, Workflows & Configs",
+        "type": "ci"
+      },
+      {
+        "hidden": false,
+        "section": ":hotsprings: CI, Workflows & Configs",
+        "type": "ops"
+      },
+      {
+        "hidden": false,
+        "section": ":hotsprings: CI, Workflows & Configs",
+        "type": "chore"
+      },
+      {
+        "hidden": false,
+        "section": ":fire: Hotfixes",
+        "type": "hotfix"
+      },
+      {
+        "hidden": false,
+        "section": ":beetle: Bug Fixes",
+        "type": "fix"
+      },
+      {
+        "hidden": false,
+        "section": ":track_previous: Reverts",
+        "type": "revert"
+      },
+      {
+        "hidden": true,
+        "type": "build"
+      },
+      {
+        "hidden": true,
+        "type": "wip"
+      },
+      {
+        "hidden": true,
+        "type": "docs"
+      },
+      {
+        "hidden": true,
+        "type": "test"
+      },
+      {
+        "hidden": true,
+        "type": "release"
+      }
+    ]
+  },
+  "tagFormat": "${version}"
+}


### PR DESCRIPTION
This pull request introduces a new configuration file `.releaserc.json` to automate the release process using semantic-release. The configuration specifies the branches, plugins, and preset rules for generating release notes and determining the type of release based on commit messages.

Key changes include:

Release automation configuration:

* Added `.releaserc.json` file to specify branches, plugins, and preset rules for semantic-release. This includes the commit analyzer, release notes generator, and GitHub release plugins.
* Defined release rules for different commit types such as `feat`, `perf`, `build`, `ops`, `refactor`, `hotfix`, `revert`, and `fix` to determine the type of release (major, minor, patch).
* Configured preset types for generating release notes with sections for breaking changes, features, enhancements, maintenance, CI, workflows, configs, hotfixes, bug fixes, and reverts.
* Set the `tagFormat` to use the version number for tagging releases.