### PR TITLE
fix(prompt): enable pip in venv

### DIFF
--- a/uv-shell.sh
+++ b/uv-shell.sh
@@ -132,7 +132,7 @@ function venv_anchor() {
         fi
 
         # Set in-venv to use pip && Add venv bin directory to PATH
-        export VIRTUAL_ENV=1
+        export PIP_REQUIRE_VIRTUALENV=false
         export PATH="$venv_path/$bin_dir:$PATH"
     fi
 }


### PR DESCRIPTION
This pull request includes a change to the `uv-shell.sh` script to modify the behavior of the virtual environment setup.

* [`uv-shell.sh`](diffhunk://#diff-f0d05f31aa090fb249167edaec562faea267de3e710b03894eca6a131464db0bL135-R135): Changed the `venv_anchor` function to set `PIP_REQUIRE_VIRTUALENV` to `false` instead of setting `VIRTUAL_ENV` to `1`.