### PR TITLE
docs(readme): add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ A fast Rust binary that creates and activates Python virtual environments using 
 
 ## Install
 
+### Homebrew (macOS/Linux)
+
+```sh
+brew tap benbenbang/forge
+brew install uv-shell
+```
+
+### From source
+
 ```sh
 cargo install --path .
 ```
@@ -23,7 +32,7 @@ cargo build --release
 # binary at target/release/uv-shell
 ```
 
-Requires [uv](https://docs.astral.sh/uv/getting-started/installation/) to be installed and on `PATH`.
+**Requirements:** [uv](https://docs.astral.sh/uv/getting-started/installation/) must be installed and on `PATH`.
 
 ## Usage
 


### PR DESCRIPTION
This pull request enhances the installation documentation by adding Homebrew as a primary installation method and reorganizing the existing installation instructions for better clarity.

**Installation documentation improvements:**
* Added new Homebrew installation section with tap and install commands for macOS and Linux users, providing a simpler installation path for these platforms.
* Reorganized installation instructions by adding clear section headers ("Homebrew" and "From source") to distinguish between different installation methods.
* Improved formatting of the requirements note by converting it from a standalone paragraph to a bold-prefixed requirement statement for better visibility.