### PR TITLE
feat(completions): switch to dynamic plugin discovery at tab-press time

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,29 +124,31 @@ The `adds-on` directory contains a small Rust binary also named `uv` that acts a
 
 ### Setup (after `brew install uv-shell`)
 
-```sh
-# Add the wrapper before the real uv in PATH
-export PATH="$(brew --prefix uv-shell)/libexec/bin:$PATH"
+**1. Add to `~/.zshrc`** (permanent, one line):
 
-# Optional: skip PATH scan on every uv call (performance)
-export UV_REAL_PATH="$(brew --prefix uv)/bin/uv"
+```sh
+export PATH="$(brew --prefix uv-shell)/libexec/bin:$PATH"
 ```
 
-Then reload completions once:
+**2. Install completions once:**
 
 ```sh
-# zsh
-unfunction _uv _uv_commands 2>/dev/null
-eval "$(uv generate-shell-completion zsh)"
+# zsh — write to fpath, auto-loaded on every new session
+uv generate-shell-completion zsh > "${fpath[1]}/_uv"
 
 # bash
-eval "$(uv generate-shell-completion bash)"
+echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
 
 # fish
-uv generate-shell-completion fish | source
+uv generate-shell-completion fish > ~/.config/fish/completions/uv.fish
 ```
 
-Add both `export` lines and the completion eval to your shell rc file so it applies to every session.
+That's it. No `eval`, no reloading. New plugins are picked up automatically on every `<TAB>`.
+
+**Optional:** skip PATH scan on every `uv` call:
+```sh
+export UV_REAL_PATH="/opt/homebrew/bin/uv"
+```
 
 ### How it works
 

--- a/adds-on/src/main.rs
+++ b/adds-on/src/main.rs
@@ -6,7 +6,13 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     match args.get(1).map(|s| s.as_str()) {
-        // Intercept completions to inject discovered plugins
+        // Dynamic plugin discovery — called by shell completion at tab-press time
+        Some("__complete") => {
+            for plugin in discover_plugins() {
+                println!("{}:Plugin: {}", plugin, plugin);
+            }
+        }
+        // Intercept completions to inject plugin hooks
         Some("generate-shell-completion") => {
             let shell = args.get(2).map(|s| s.as_str()).unwrap_or("bash");
             generate_completions(shell);
@@ -162,25 +168,28 @@ fn inject_bash(completions: String, plugins: &[String]) -> String {
     )
 }
 
-/// Zsh: inject plugins into `_uv_commands()` list, add case dispatch, and
-/// append each plugin's completion function body.
+/// Zsh: inject a dynamic plugin lookup into `_uv_commands()` so that
+/// `uv <TAB>` discovers plugins at tab-press time (no re-eval needed).
+/// Sub-completions (`uv shell <TAB>`) are still injected statically since
+/// zsh needs the function body defined in the session.
 fn inject_zsh(completions: String, plugins: &[String]) -> String {
-    // Step 1: add plugins to the _uv_commands() list
-    let plugin_entries: String = plugins
-        .iter()
-        .map(|p| format!("'{}:Plugin: {}' \\\n", p, p))
-        .collect();
-
+    // Step 1: replace the static _describe call with a dynamic one that also
+    // calls `uv __complete` at tab-press time
+    let dynamic_block = concat!(
+        "    # Dynamic plugin discovery — merge into commands at tab-press time\n",
+        "    local -a _uv_plugins\n",
+        "    _uv_plugins=(\"${(@f)$(uv __complete 2>/dev/null)}\")\n",
+        "    (( ${#_uv_plugins} )) && commands+=($_uv_plugins)\n",
+        "    _describe -t commands 'uv commands' commands \"$@\"\n",
+        "}",
+    );
     let mut result = completions.replace(
-        "'help:Display documentation for a command' \\\n    )",
-        &format!(
-            "'help:Display documentation for a command' \\\n{}    )",
-            plugin_entries
-        ),
+        "    _describe -t commands 'uv commands' commands \"$@\"\n}",
+        dynamic_block,
     );
 
-    // Step 2: for each plugin that supports `completions zsh`, inject a case
-    // dispatch and append its function definitions
+    // Step 2: for each currently installed plugin that supports `completions zsh`,
+    // inject a case dispatch and append its function body
     for plugin in plugins {
         if let Some(body) = plugin_zsh_body(plugin) {
             result = inject_zsh_dispatch(result, plugin, &body);
@@ -264,12 +273,13 @@ mod tests {
     }
 
     #[test]
-    fn test_inject_zsh_appends_plugins() {
-        let fake = "'help:Display documentation for a command' \\\n    )".to_string();
-        let plugins = vec!["shell".to_string()];
-        let result = inject_zsh(fake, &plugins);
-        assert!(result.contains("'shell:Plugin: shell'"));
-        assert!(result.contains("'help:Display documentation for a command'"));
+    fn test_inject_zsh_dynamic_lookup() {
+        let fake = "    _describe -t commands 'uv commands' commands \"$@\"\n}".to_string();
+        let result = inject_zsh(fake, &[]);
+        assert!(result.contains("uv __complete"), "should inject dynamic __complete call");
+        assert!(result.contains("_uv_plugins"), "should declare _uv_plugins array");
+        assert!(result.contains("commands+=($_uv_plugins)"), "should merge plugins into commands");
+        assert!(result.contains("_describe -t commands 'uv commands'"), "should use single describe call");
     }
 
     #[test]


### PR DESCRIPTION
This pull request refactors the shell completion system to discover plugins dynamically at tab-press time instead of requiring shell re-evaluation, and simplifies the installation instructions. The main changes improve user experience by eliminating manual reloading steps and reducing setup complexity.

**Dynamic plugin discovery:**
* Added a new `__complete` command in `adds-on/src/main.rs` that outputs discovered plugins in completion format, called dynamically by the shell at tab-press time.
* Refactored `inject_zsh()` to replace the static plugin list with a dynamic lookup that calls `uv __complete` during tab completion, automatically picking up newly installed plugins without re-evaluation.
* Updated Zsh completion injection to merge dynamically discovered plugins into the commands array at runtime while keeping sub-command completions statically injected.
* Modified tests to validate the new dynamic lookup mechanism instead of static plugin injection.

**Documentation improvements:**
* Simplified setup instructions in `README.md` to use a single-line PATH export and one-time completion installation, eliminating the need for `eval` or manual reloading.
* Updated completion installation to write directly to completion directories (fpath for zsh, config files for bash/fish) for automatic loading on every new session.
* Clarified that new plugins are picked up automatically on every tab-press without additional configuration.
* Made the `UV_REAL_PATH` optimization optional and moved it to a separate section.