### PR TITLE
feat(completions): add nushell shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,11 @@ export PATH="$(brew --prefix uv-shell)/libexec/bin:$PATH"
 **2. Install completions once:**
 
 ```sh
-# zsh — write to fpath, auto-loaded on every new session
+# zsh — auto-loaded every session, plugins discovered dynamically at tab-press time
 uv generate-shell-completion zsh > "${fpath[1]}/_uv"
+
+# nushell — then add `use ~/.config/nushell/completions/uv.nu` to config.nu
+uv generate-shell-completion nushell | save ~/.config/nushell/completions/uv.nu
 
 # bash
 echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
@@ -143,7 +146,9 @@ echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
 uv generate-shell-completion fish > ~/.config/fish/completions/uv.fish
 ```
 
-That's it. No `eval`, no reloading. New plugins are picked up automatically on every `<TAB>`.
+**zsh:** no `eval`, no reloading — new plugins appear at tab-press time automatically.
+
+**nushell / bash / fish:** re-run the above after installing new plugins.
 
 **Optional:** skip PATH scan on every `uv` call:
 ```sh

--- a/adds-on/src/main.rs
+++ b/adds-on/src/main.rs
@@ -151,6 +151,7 @@ fn generate_completions(shell: &str) {
             "bash" => inject_bash(completions, &plugins),
             "zsh" => inject_zsh(completions, &plugins),
             "fish" => inject_fish(completions, &plugins),
+            "nushell" => inject_nushell(completions, &plugins),
             _ => completions,
         }
     };
@@ -241,6 +242,56 @@ fn inject_zsh_dispatch(completions: String, plugin: &str, body: &str) -> String 
     format!("{}\n{}", with_case, body)
 }
 
+/// Nushell: inject plugin externs into the `module completions` block.
+/// Each plugin's `extern "uv-<name>"` is renamed to `extern "uv <name>"`
+/// so nushell naturally shows it as a subcommand of `uv`.
+fn inject_nushell(completions: String, plugins: &[String]) -> String {
+    let mut result = completions;
+    for plugin in plugins {
+        if let Some(body) = plugin_nushell_body(plugin) {
+            result = result.replace(
+                "\n}\n\nexport use completions *",
+                &format!("\n{}\n}}\n\nexport use completions *", body),
+            );
+        }
+    }
+    result
+}
+
+/// Run `uv-<plugin> completions nushell`, strip the module wrapper, and
+/// rename all `uv-<plugin>` references to `uv <plugin>` so the externs
+/// integrate cleanly into uv's own `module completions`.
+fn plugin_nushell_body(plugin: &str) -> Option<String> {
+    let path = find_in_path(&format!("uv-{}", plugin))?;
+
+    let output = Command::new(&path)
+        .args(["completions", "nushell"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    let module_name = format!("uv-{}-completions", plugin);
+    let plugin_cmd = format!("uv-{}", plugin);
+    let uv_cmd = format!("uv {}", plugin);
+
+    let body = text
+        .lines()
+        // strip module wrapper and use statement
+        .filter(|l| !l.starts_with("module ") && !l.starts_with("use "))
+        // rename "uv-shell" → "uv shell" everywhere (extern names + nu-complete refs)
+        .map(|l| l.replace(&plugin_cmd, &uv_cmd))
+        // strip the auto-generated module name from nu-complete function names
+        .map(|l| l.replace(&module_name, &format!("uv {}", plugin)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(body)
+}
+
 /// Fish: append `complete` lines for each plugin at the end.
 fn inject_fish(completions: String, plugins: &[String]) -> String {
     let plugin_cmds: String = plugins
@@ -280,6 +331,19 @@ mod tests {
         assert!(result.contains("_uv_plugins"), "should declare _uv_plugins array");
         assert!(result.contains("commands+=($_uv_plugins)"), "should merge plugins into commands");
         assert!(result.contains("_describe -t commands 'uv commands'"), "should use single describe call");
+    }
+
+    #[test]
+    fn test_inject_nushell_appends_plugin() {
+        let fake = "module completions {\n  export extern uv [\n  ]\n}\n\nexport use completions *".to_string();
+        let body = "  export extern \"uv shell\" [\n    --help\n  ]".to_string();
+        // simulate inject_nushell by calling the replace logic directly
+        let result = fake.replace(
+            "\n}\n\nexport use completions *",
+            &format!("\n{}\n}}\n\nexport use completions *", body),
+        );
+        assert!(result.contains("export extern \"uv shell\""));
+        assert!(result.contains("export use completions *"));
     }
 
     #[test]


### PR DESCRIPTION
This pull request adds native nushell shell completion support to the uv-plugin-completion system, enabling nushell users to get dynamic plugin completions alongside the core uv command. The changes include implementation of nushell completion injection and updated documentation.

**Nushell completion integration:**
* Added `inject_nushell` function in `adds-on/src/main.rs` that injects plugin externs into the nushell `module completions` block, merging plugin completions seamlessly with uv's native completions.
* Implemented `plugin_nushell_body` helper that extracts completion definitions from each plugin by running `uv-<plugin> completions nushell`, strips module wrappers, and renames `uv-<plugin>` references to `uv <plugin>` for natural subcommand integration.
* Added nushell case handling in the main shell completion dispatcher to route nushell requests through the new injection logic.
* Included unit test `test_inject_nushell_appends_plugin` to verify correct insertion of plugin externs into the completions module.

**Documentation updates:**
* Updated `README.md` installation instructions to include nushell completion setup with `uv generate-shell-completion nushell` and config.nu integration steps.
* Clarified that zsh completions discover plugins dynamically at tab-press time with no eval or reloading needed, while nushell/bash/fish require re-running completion generation after installing new plugins.
* Improved comment clarity for zsh installation, emphasizing dynamic plugin discovery behavior.