### PR TITLE
fix(completions): export uv-shell-completions module

### DIFF
--- a/src/completions/uv-shell.nu
+++ b/src/completions/uv-shell.nu
@@ -74,4 +74,4 @@ module uv-shell-completions {
     ]
 }
 
-use uv-shell-completions *
+export use uv-shell-completions *


### PR DESCRIPTION
This pull request updates the Nushell completion file to properly export the uv-shell-completions module, making its functions available to other modules that import this file.

**Completion module export fix:**
* Modified `src/completions/uv-shell.nu` to change `use uv-shell-completions *` to `export use uv-shell-completions *`, ensuring that the completions are properly exported and accessible to importing modules.