### PR TITLE
docs(readme): clarify prompt customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ uv-shell --seed
 # Re-create an existing venv
 uv-shell --clear
 
-# Custom prompt instead of auto-generated <project>-py<version>
-uv-shell --prompt my-env
+# Override just the project name (keeps -pyX.XX suffix)
+uv-shell --prefix myproject       # → myproject-py3.12
+
+# Full custom prompt (replaces everything)
+uv-shell --prompt my-env          # → my-env
 ```
 
 All options are forwarded to `uv venv`. Run `uv-shell --help` or `uv venv --help` for the full list.


### PR DESCRIPTION
This pull request updates the README documentation to better explain the two different ways to customize the virtual environment prompt. The changes clarify the distinction between prefix and prompt options for better user understanding.

**Documentation improvements:**
* Replaced the single `--prompt` example with two distinct examples showing `--prefix` and `--prompt` options
* Added inline comments demonstrating the output format for `--prefix` (which keeps the `-pyX.XX` suffix) versus `--prompt` (which replaces everything)
* Improved clarity on how each option affects the final prompt appearance, making it easier for users to choose the right option for their needs