### PR TITLE
fix(venv): filter --prefix flag before forwarding to uv venv

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,22 @@ fn main() {
     let needs_create = !venv_path.is_dir() || has_clear;
 
     if needs_create {
-        create_venv(&venv_path, user_args);
+        // Strip --prefix and its value — it's our flag, unknown to `uv venv`
+        let forwarded: Vec<String> = {
+            let mut out = Vec::new();
+            let mut iter = user_args.iter();
+            while let Some(arg) = iter.next() {
+                if arg == "--prefix" {
+                    iter.next(); // skip value
+                } else if arg.starts_with("--prefix=") {
+                    // skip entirely
+                } else {
+                    out.push(arg.clone());
+                }
+            }
+            out
+        };
+        create_venv(&venv_path, &forwarded);
     }
 
     if !has_custom_prompt {


### PR DESCRIPTION
This commit prevents the custom --prefix flag from being passed to the underlying `uv venv` command, which does not recognize it. The changes ensure that only valid arguments are forwarded during virtual environment creation.

**Argument filtering logic:**
* Added filtering logic in `src/main.rs` to strip both `--prefix` and `--prefix=value` forms from user arguments before passing them to `create_venv()`.
* The filtered arguments are collected into a new vector that excludes the custom flag and its value, preventing errors from the underlying `uv venv` command.