### PR TITLE
fix(adds-on): update shell completion setup example

### DIFF
--- a/adds-on/src/main.rs
+++ b/adds-on/src/main.rs
@@ -29,7 +29,7 @@ ENVIRONMENT:
 
 SETUP:
     export PATH=\"$(brew --prefix uv-shell)/libexec/bin:$PATH\"
-    uv generate-shell-completion zsh > \"\${fpath[1]}/_uv\"
+    uv generate-shell-completion zsh > \"<your-fpath>/_uv\"
 
 Any unrecognised command is forwarded to the real uv unchanged."
     );


### PR DESCRIPTION
This commit updates the documentation in the help text to make the shell completion setup instructions more generic and clearer for users.

**Documentation improvement:**
* Changed the shell completion setup example in `adds-on/src/main.rs` from using `${fpath[1]}` to `<your-fpath>` placeholder, making it clearer that users need to substitute their actual fpath location rather than literally using the array syntax.