### PR TITLE
feat(cli): add version flag support to wrapper and main binary

### DIFF
--- a/adds-on/src/main.rs
+++ b/adds-on/src/main.rs
@@ -21,6 +21,7 @@ SPECIAL COMMANDS:
                         →  real uv completions + plugins injected
                            shells: bash zsh fish nushell
     uv __complete       →  list discovered plugins (used by shell completions)
+    uv --version, -V    →  show wrapper version
     uv --help, -h       →  show this message
 
 ENVIRONMENT:
@@ -41,6 +42,9 @@ fn main() {
     match args.get(1).map(|s| s.as_str()) {
         Some("-h") | Some("--help") => {
             print_help();
+        }
+        Some("--version") | Some("-V") => {
+            println!("uv (plugin wrapper) {}", env!("CARGO_PKG_VERSION"));
         }
         // Dynamic plugin discovery — called by shell completion at tab-press time
         Some("__complete") => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,7 @@ Options (forwarded to `uv venv`):
       --no-config               Avoid discovering configuration files
   -q, --quiet                   Quiet output
   -v, --verbose                 Verbose output
+  -V, --version                 Show version
   -h, --help                    Show this help message
 
 All other `uv venv` options are also forwarded. See `uv venv --help` for the full list.
@@ -360,6 +361,10 @@ fn main() {
     // Subcommand dispatch
     if let Some(first) = user_args.first() {
         match first.as_str() {
+            "--version" | "-V" => {
+                println!("uv-shell {}", env!("CARGO_PKG_VERSION"));
+                return;
+            }
             "anchor" => {
                 let anchor_args = &user_args[1..];
                 let shell_override = parse_anchor_shell(anchor_args);


### PR DESCRIPTION
This pull request adds version flag support to both the uv plugin wrapper (adds-on) and the main uv-shell binary, allowing users to check the version of each component independently.

**Version flag implementation:**
* Added `--version` and `-V` flag handling to `adds-on/src/main.rs` that displays the plugin wrapper version using the CARGO_PKG_VERSION environment variable at compile time.
* Added `--version` and `-V` flag handling to `src/main.rs` that displays the uv-shell version, providing early exit before subcommand dispatch.

**Documentation updates:**
* Updated help text in both binaries to document the new version flags, making them discoverable through `--help` output.