### PR TITLE
feat(anchor): add stderr message when no venv found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,10 @@ fn anchor(shell_override: Option<&str>) {
     let cfg_path = venv_path.join("pyvenv.cfg");
 
     if !venv_path.is_dir() || !cfg_path.exists() {
+        eprintln!(
+            "uv-shell anchor: no .venv found in {}",
+            venv_path.parent().unwrap_or(&venv_path).display()
+        );
         return;
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,7 +59,7 @@ fn help_short_flag() {
 // ── anchor (default / bash) ─────────────────────────────────────
 
 #[test]
-fn anchor_no_venv_silent() {
+fn anchor_no_venv_reports_on_stderr() {
     let dir = tmpdir("anchor-none");
     let out = Command::new(bin())
         .arg("anchor")
@@ -69,7 +69,12 @@ fn anchor_no_venv_silent() {
     assert!(out.status.success());
     assert!(
         out.stdout.is_empty(),
-        "anchor should produce no output without .venv"
+        "anchor should produce no stdout without .venv"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no .venv found"),
+        "anchor should explain why it produced no output, got: {stderr}"
     );
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
This pull request improves the user experience when running the anchor command without a virtual environment by providing clear feedback on stderr, and updates the integration test to verify this behavior.

**Anchor command enhancement:**
* Modified `src/main.rs` to print an informative message to stderr when no `.venv` directory is found, showing the path where the search was performed
* The message follows the format "uv-shell anchor: no .venv found in <path>" to help users understand why no output was produced

**Test updates:**
* Renamed test `anchor_no_venv_silent` to `anchor_no_venv_reports_on_stderr` in `tests/integration.rs` to better reflect the new behavior
* Updated test assertions to verify that stdout remains empty while stderr contains the expected "no .venv found" message