### PR TITLE
refactor(anchor): remove activated marker file functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -221,12 +221,6 @@ fn anchor(shell_override: Option<&str>) {
     let bin_dir = get_bin_dir();
     let venv_bin = venv_path.join(bin_dir);
 
-    // Touch the activated marker file
-    let activated_path = venv_path.join("activated");
-    if !activated_path.exists() {
-        let _ = fs::File::create(&activated_path);
-    }
-
     let shell = shell_override.unwrap_or_else(|| detect_shell());
     let venv = venv_path.display();
     let bin = venv_bin.display();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -128,21 +128,6 @@ fn anchor_finds_venv_in_parent_directory() {
     let _ = fs::remove_dir_all(&dir);
 }
 
-#[test]
-fn anchor_creates_activated_marker() {
-    let dir = tmpdir_with_venv("anchor-marker");
-
-    assert!(!dir.join(".venv/activated").exists());
-
-    Command::new(bin())
-        .arg("anchor")
-        .current_dir(&dir)
-        .output()
-        .unwrap();
-
-    assert!(dir.join(".venv/activated").exists());
-    let _ = fs::remove_dir_all(&dir);
-}
 
 // ── anchor --shell (per-shell output formats) ───────────────────
 


### PR DESCRIPTION
This commit removes the activated marker file feature from the anchor command, simplifying the codebase by eliminating unused functionality. The changes include removal of file creation logic and associated tests.

**Anchor command simplification:**
* Removed code in `src/main.rs` that created an "activated" marker file in the virtual environment directory when running the anchor command, as this marker was not being used by any other part of the system.

**Test cleanup:**
* Removed the `anchor_creates_activated_marker` integration test from `tests/integration.rs` that verified the creation of the activated marker file, as this functionality is no longer present.