### PR TITLE
feat(shell): improve shell detection with direct environment checks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,19 @@ fn get_venv_path() -> PathBuf {
 }
 
 /// Auto-detect the current shell from environment.
+///
+/// Check order:
+///   1. `$FISH_VERSION`   — set by fish itself, reliable even when $SHELL lags
+///   2. `$NU_VERSION`     — set by nushell
+///   3. `$SHELL`          — login shell; may differ from the running shell
+///   4. `$PSModulePath`   — PowerShell
 fn detect_shell() -> &'static str {
+    if env::var("FISH_VERSION").is_ok() {
+        return "fish";
+    }
+    if env::var("NU_VERSION").is_ok() {
+        return "nushell";
+    }
     if let Ok(shell) = env::var("SHELL") {
         if shell.contains("fish") {
             return "fish";


### PR DESCRIPTION
This commit enhances the shell auto-detection logic to be more reliable by checking shell-specific environment variables before falling back to the generic SHELL variable. The changes prioritize direct shell indicators over the login shell setting.

**Shell detection improvements:**
* Added direct detection for Fish shell via `$FISH_VERSION` environment variable, which is set by Fish itself and is more reliable than parsing `$SHELL`
* Added direct detection for Nushell via `$NU_VERSION` environment variable
* Reordered detection logic to check shell-specific variables first (`$FISH_VERSION`, `$NU_VERSION`) before falling back to `$SHELL` and `$PSModulePath`
* Added inline documentation explaining the detection order and rationale for each check