### PR TITLE
fix(workspace): convert to Cargo workspace and bump version to 2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,9 @@
 version = 4
 
 [[package]]
+name = "uv"
+version = "2.6.0"
+
+[[package]]
 name = "uv-shell"
-version = "1.0.0"
+version = "2.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,20 @@
-[package]
-name = "uv-shell"
-version = "1.0.0"
+[workspace]
+members = ["adds-on"]
+
+[workspace.package]
+version = "2.6.0"
 edition = "2024"
 license = "MIT"
-description = "Create and activate Python virtual environments with uv"
 repository = "https://github.com/benbenbang/uv-shell"
 authors = ["benbenbang <bn@bitbrew.dev>"]
+
+[package]
+name = "uv-shell"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Create and activate Python virtual environments with uv"
+repository.workspace = true
+authors.workspace = true
 
 [dependencies]

--- a/adds-on/Cargo.toml
+++ b/adds-on/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "uv"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "uv wrapper with plugin discovery (uv-xxx → uv xxx)"
-license = "MIT"
+license.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This pull request restructures the project into a Cargo workspace configuration and updates the version across all packages. The main changes consolidate shared package metadata and establish a multi-crate workspace structure.

**Workspace configuration:**
* Converted root `Cargo.toml` to a workspace configuration with "adds-on" as a member crate
* Defined shared workspace package metadata including version (2.6.0), edition (2024), and license (MIT)
* Moved repository and authors fields to workspace-level configuration for reuse across member crates

**Package updates:**
* Updated `adds-on/Cargo.toml` to use workspace-inherited values for version, edition, and license fields
* Updated root package `uv-shell` to reference workspace-level metadata fields
* Bumped version from 1.0.0 to 2.6.0 across all packages in `Cargo.lock`