### PR TITLE
fix(venv): preserve custom prompt when reusing existing venv

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -532,7 +532,10 @@ fn main() {
         create_venv(&venv_path, &forwarded);
     }
 
-    if !has_custom_prompt {
+    // Only update the prompt when we just created (or recreated) the venv.
+    // Reusing an existing venv leaves pyvenv.cfg untouched so any prompt set
+    // during creation (via --prompt or --prefix) is preserved.
+    if needs_create && !has_custom_prompt {
         update_prompt(&venv_path, prefix.as_deref());
     }
 


### PR DESCRIPTION
This commit fixes an issue where custom prompts set during virtual environment creation were being overwritten when reusing an existing venv. The prompt update logic now only runs when a new venv is created or recreated.

**Prompt preservation logic:**
* Modified the prompt update condition in `src/main.rs` to check both `needs_create` and `!has_custom_prompt` before updating the prompt, ensuring that existing venvs with custom prompts (set via --prompt or --prefix) are left untouched when reused.
* Added clarifying comments explaining that reusing an existing venv preserves the pyvenv.cfg file and any prompt configuration from the original creation.