### PR TITLE
ci(.github): update prek container image source

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,40 +4,39 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    name: pre-commit checks
+    uses: benbenbang/reusable-workflows/.github/workflows/prek.yml@1.0.1
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+
   pr-labeler:
+    name: pr labeler
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: pr labeler
         uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
-
-  rust-build-and-tests:
-    runs-on: ubuntu-latest
-    container: ghcr.io/benbenbang/uv-shell/prek
-    permissions:
-      contents: read
-      pull-requests: write
-      packages: read
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v5
-      - name: build binary
-        run: cargo build --verbose
-      - name: run test
-        run: cargo test --verbose
-    env:
-      CARGO_TERM_COLOR: always


### PR DESCRIPTION
This change updates the container image used in the `rust-build-and-tests` job within the pull request workflow. The image source is changed from `ghcr.io/benbenbang/uv-shell/prek` to `ghcr.io/benbenbang/reusable-workkflows/prek` to reflect the new image location.